### PR TITLE
feat: add repeating blended noise

### DIFF
--- a/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/FLTDensityFunctions.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/FLTDensityFunctions.java
@@ -3,6 +3,7 @@ package com.smallmanseries.farlandstraveler.common.worldgen;
 import com.mojang.serialization.MapCodec;
 import com.smallmanseries.farlandstraveler.FarLandsTraveler;
 import com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions.BlendedNoiseOverflowable;
+import com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions.BlendedNoiseRepeating;
 import com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions.VirtualDensityFunction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.levelgen.DensityFunction;
@@ -15,5 +16,6 @@ public class FLTDensityFunctions {
     static {
         FUNCTIONS.register("virtual_density_function", () -> VirtualDensityFunction.DATA_CODEC);
         FUNCTIONS.register("old_blended_noise_overflowable", () -> BlendedNoiseOverflowable.DATA_CODEC);
+        FUNCTIONS.register("old_blended_noise_repeating", () -> BlendedNoiseRepeating.DATA_CODEC);
     }
 }

--- a/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/densityfunctions/BlendedNoiseOverflowable.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/densityfunctions/BlendedNoiseOverflowable.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.levelgen.synth.BlendedNoise;
  * 可溢出的混合噪声，用于创建可生成边境之地的自定义噪声。由 {@link BlendedNoiseMixin} 基于修改原版的 {@link BlendedNoise} 类来实现。
  */
 public class BlendedNoiseOverflowable extends BlendedNoise{
-    private static final Codec<Double> SCALE_RANGE = Codec.doubleRange(0.001, 1000.0);
+    protected static final Codec<Double> SCALE_RANGE = Codec.doubleRange(0.001, 1000.0);
     public static final MapCodec<BlendedNoiseOverflowable> DATA_CODEC = RecordCodecBuilder.mapCodec(
             instance -> instance.group(
                             SCALE_RANGE.fieldOf("xz_scale").forGetter(instance1 -> instance1.xzScale),

--- a/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/densityfunctions/BlendedNoiseRepeating.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/common/worldgen/densityfunctions/BlendedNoiseRepeating.java
@@ -1,0 +1,102 @@
+package com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import net.minecraft.world.level.levelgen.synth.BlendedNoise;
+
+/**
+ * 可循环、可选溢出的混合噪声，用于创建“循环边境之地”的地形。
+ * @author INF32768
+ */
+public class BlendedNoiseRepeating extends BlendedNoiseOverflowable {
+    /**
+     * 是否可溢出。若为 true，则噪声会在坐标为 2^31 ÷ xzScale ÷ 684.412 的位置溢出，形成边境之地。
+     * <p>
+     * 由 {@link com.smallmanseries.farlandstraveler.mixin.worldgen.BlendedNoiseMixin} 根据此变量修改原版类实现溢出。
+     */
+    public final boolean canOverflow;
+    /**
+     * 循环起点。必须为正数。当任意一轴的坐标的绝对值大于此值时，该轴上的噪声值将开始按照设定的模式进行循环。
+     * <p>
+     * 建议为 8 的倍数，否则后续的线性插值可能破坏循环模式。
+     */
+    private final int repeatStart;
+    /**
+     * 单个循环区域内每个循环节的长度。必须为正数。
+     * <p>
+     * 建议为 8 的倍数，否则后续的线性插值可能破坏循环模式。
+     */
+    private final int repeatLength;
+    /**
+     * 每个循环区域内循环节的数量。必须为正数。
+     */
+    private final int repeatCount;
+
+    private static final Codec<Integer> POSITIVE_INT_RANGE = Codec.intRange(1, Integer.MAX_VALUE);
+
+    public static final MapCodec<BlendedNoiseRepeating> DATA_CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                            Codec.BOOL.fieldOf("can_overflow").forGetter(instance1 -> instance1.canOverflow),
+                            POSITIVE_INT_RANGE.fieldOf("repeat_start").forGetter(instance1 -> instance1.repeatStart),
+                            POSITIVE_INT_RANGE.fieldOf("repeat_length").forGetter(instance1 -> instance1.repeatLength),
+                            POSITIVE_INT_RANGE.fieldOf("repeat_count").forGetter(instance1 -> instance1.repeatCount),
+                            SCALE_RANGE.fieldOf("xz_scale").forGetter(instance1 -> instance1.xzScale),
+                            SCALE_RANGE.fieldOf("y_scale").forGetter(instance1 -> instance1.yScale),
+                            SCALE_RANGE.fieldOf("xz_factor").forGetter(instance1 -> instance1.xzFactor),
+                            SCALE_RANGE.fieldOf("y_factor").forGetter(instance1 -> instance1.yFactor),
+                            Codec.doubleRange(1.0, 8.0).fieldOf("smear_scale_multiplier").forGetter(instance1 -> instance1.smearScaleMultiplier)
+                    )
+                    .apply(instance, BlendedNoiseRepeating::createUnseeded)
+    );
+
+    public BlendedNoiseRepeating(RandomSource random, double xzScale, double yScale, double xzFactor, double yFactor, double smearScaleMultiplier, boolean canOverflow, int repeatStart, int repeatLength, int repeatCount) {
+        super(random, xzScale, yScale, xzFactor, yFactor, smearScaleMultiplier);
+        this.canOverflow = canOverflow;
+        this.repeatStart = repeatStart;
+        this.repeatLength = repeatLength;
+        this.repeatCount = repeatCount;
+    }
+
+    public static BlendedNoiseRepeating createUnseeded(boolean canOverflow, int repeatStart, int repeatLength, int repeatCount, double xzScale, double yScale, double xzFactor, double yFactor, double smearScaleMultiplier) {
+        return new BlendedNoiseRepeating(new XoroshiroRandomSource(0L), xzScale, yScale, xzFactor, yFactor, smearScaleMultiplier, canOverflow, repeatStart, repeatLength, repeatCount);
+    }
+
+    @Override
+    public BlendedNoiseOverflowable withNewRandom(RandomSource random) {
+        return new BlendedNoiseRepeating(random, this.xzScale, this.yScale, this.xzFactor, this.yFactor, this.smearScaleMultiplier, this.canOverflow, this.repeatStart, this.repeatLength, this.repeatCount);
+    }
+
+    /**
+     * 计算指定坐标处的噪声值。实际上只是将计算的坐标修改为循环模式下的坐标，并调用原版的 {@link BlendedNoise#compute(FunctionContext)} 的方法计算。
+     * @param context 计算上下文，由密度函数调用器提供
+     * @return 指定坐标处的噪声值
+     */
+    @Override
+    public double compute(FunctionContext context) {
+        int sectionLength = this.repeatLength * this.repeatCount;
+
+        int x = context.blockX();
+        if (Math.abs(x) >= repeatStart) {
+            int a = x - repeatStart;
+            x = a % repeatLength + repeatStart + (a / sectionLength) * sectionLength;
+        }
+
+        int y = context.blockY();
+        if (Math.abs(y) > repeatStart) {
+            int a = y - repeatStart;
+            y = a % repeatLength + repeatStart + (a / sectionLength) * sectionLength;
+        }
+
+        int z = context.blockZ();
+        if (Math.abs(z) > repeatStart) {
+            int a = z - repeatStart;
+            z = a % repeatLength + repeatStart + (a / sectionLength) * sectionLength;
+        }
+
+        context = new SinglePointContext(x, y, z);
+        return super.compute(context);
+    }
+}

--- a/src/main/java/com/smallmanseries/farlandstraveler/mixin/worldgen/BlendedNoiseMixin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/mixin/worldgen/BlendedNoiseMixin.java
@@ -1,6 +1,7 @@
 package com.smallmanseries.farlandstraveler.mixin.worldgen;
 
 import com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions.BlendedNoiseOverflowable;
+import com.smallmanseries.farlandstraveler.common.worldgen.densityfunctions.BlendedNoiseRepeating;
 import net.minecraft.world.level.levelgen.synth.BlendedNoise;
 import net.minecraft.world.level.levelgen.synth.PerlinNoise;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,6 +23,9 @@ public abstract class BlendedNoiseMixin {
     @Redirect(method = "compute", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/levelgen/synth/PerlinNoise;wrap(D)D"))
     private double redirectWrap(double value) {
         if(((BlendedNoise)(Object)this) instanceof BlendedNoiseOverflowable) {
+            if (((BlendedNoise)(Object)this) instanceof BlendedNoiseRepeating) {
+                return ((BlendedNoiseRepeating)(Object)this).canOverflow ? value : PerlinNoise.wrap(value);
+            }
             return value;
         }
         return PerlinNoise.wrap(value);

--- a/src/main/resources/data/farlandstraveler/worldgen/density_function/overworld/base_3d_noise_12550825.json
+++ b/src/main/resources/data/farlandstraveler/worldgen/density_function/overworld/base_3d_noise_12550825.json
@@ -1,5 +1,9 @@
 {
-  "type": "farlandstraveler:old_blended_noise_overflowable",
+  "type": "farlandstraveler:old_blended_noise_repeating",
+  "can_overflow": true,
+  "repeat_start": 12560824,
+  "repeat_length": 16,
+  "repeat_count": 3,
   "smear_scale_multiplier": 8.0,
   "xz_factor": 80.0,
   "xz_scale": 0.25,


### PR DESCRIPTION
可循环、可选溢出的混合噪声

修改了 src/main/resources/data/farlandstraveler/worldgen/density_function/overworld/base_3d_noise_12550825.json 配置，使其于 12560824 处开始循环，便于测试。