### PR TITLE
feat: make Stripe Lands' rendering effects compatible with Sodium Mod

### DIFF
--- a/src/main/java/com/smallmanseries/farlandstraveler/MixinConfigPlugin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/MixinConfigPlugin.java
@@ -1,0 +1,43 @@
+package com.smallmanseries.farlandstraveler;
+
+import net.neoforged.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinConfigPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // 仅在 Sodium 有安装时加载相关 Mixins
+        return !mixinClassName.contains("sodium") || LoadingModList.get().getModFileById("sodium") != null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/BlockRendererMixin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/BlockRendererMixin.java
@@ -1,0 +1,21 @@
+package com.smallmanseries.farlandstraveler.mixin.sodium;
+
+import com.smallmanseries.farlandstraveler.Config;
+import net.caffeinemc.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderer;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockRenderer.class)
+public abstract class BlockRendererMixin {
+    @Inject(method = "renderModel", at = @At("HEAD"), cancellable = true)
+    private void modifyRenderer(BlockStateModel model, BlockState state, BlockPos pos, BlockPos origin, CallbackInfo ci) {
+        int stripeLandsDistance = Config.STRIPE_LANDS_DISTANCE.getAsInt();
+        if (stripeLandsDistance == -1) return;
+        if (Math.abs(pos.getX()) >= stripeLandsDistance && (pos.getX() & 1) == 1 || Math.abs(pos.getZ()) >= stripeLandsDistance && (pos.getZ() & 1) == 1) ci.cancel();
+    }
+}

--- a/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/FluidRendererImplMixin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/FluidRendererImplMixin.java
@@ -1,0 +1,24 @@
+package com.smallmanseries.farlandstraveler.mixin.sodium;
+
+import com.smallmanseries.farlandstraveler.Config;
+import net.caffeinemc.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
+import net.caffeinemc.mods.sodium.client.render.chunk.translucent_sorting.TranslucentGeometryCollector;
+import net.caffeinemc.mods.sodium.client.world.LevelSlice;
+import net.caffeinemc.mods.sodium.neoforge.render.FluidRendererImpl;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(FluidRendererImpl.class)
+public abstract class FluidRendererImplMixin {
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+    private void modifyRenderer(LevelSlice level, BlockState blockState, FluidState fluidState, BlockPos blockPos, BlockPos offset, TranslucentGeometryCollector collector, ChunkBuildBuffers buffers, CallbackInfo ci) {
+        int stripeLandsDistance = Config.STRIPE_LANDS_DISTANCE.getAsInt();
+        if (stripeLandsDistance == -1) return;
+        if (Math.abs(blockPos.getX()) >= stripeLandsDistance && (blockPos.getX() & 1) == 1 || Math.abs(blockPos.getZ()) >= stripeLandsDistance && (blockPos.getZ() & 1) == 1) ci.cancel();
+    }
+}

--- a/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/SodiumWorldRendererMixin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/mixin/sodium/SodiumWorldRendererMixin.java
@@ -1,0 +1,31 @@
+package com.smallmanseries.farlandstraveler.mixin.sodium;
+
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.smallmanseries.farlandstraveler.Config;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import net.caffeinemc.mods.sodium.client.render.SodiumWorldRenderer;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderBuffers;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.BlockDestructionProgress;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.SortedSet;
+
+@Mixin(SodiumWorldRenderer.class)
+public abstract class SodiumWorldRendererMixin {
+    @Inject(method = "renderBlockEntity", at = @At("HEAD"), cancellable = true)
+    private static void modifyRenderer(PoseStack matrices, RenderBuffers bufferBuilders, Long2ObjectMap<SortedSet<BlockDestructionProgress>> blockBreakingProgressions, float tickDelta, MultiBufferSource.BufferSource immediate, double x, double y, double z, BlockEntityRenderDispatcher dispatcher, BlockEntity entity, LocalPlayer player, LocalBooleanRef isGlowing, CallbackInfo ci) {
+        int stripeLandsDistance = Config.STRIPE_LANDS_DISTANCE.getAsInt();
+        if (stripeLandsDistance == -1) return;
+        BlockPos pos = entity.getBlockPos();
+        if (Math.abs(pos.getX()) >= stripeLandsDistance && (pos.getX() & 1) == 1 || Math.abs(pos.getZ()) >= stripeLandsDistance && (pos.getZ() & 1) == 1) ci.cancel();
+    }
+}

--- a/src/main/resources/farlandstraveler.mixins.json
+++ b/src/main/resources/farlandstraveler.mixins.json
@@ -35,6 +35,10 @@
     "renderer.BlockEntityRendererDispatcherMixin",
     "renderer.LiquidBlockRendererMixin",
     "renderer.ModelBlockRendererMixin",
+    "sodium.BlockRendererMixin",
+    "sodium.FluidRendererImplMixin",
+    "sodium.SodiumWorldRendererMixin",
     "structureblock.BlockEntityWithBoundingBoxRenderMixin"
-  ]
+  ],
+  "plugin": "com.smallmanseries.farlandstraveler.MixinConfigPlugin"
 }


### PR DESCRIPTION
让条纹之地渲染效果和钠兼容，同时添加了 `MixinConfigPlugin` 来确保只有钠安装时才加载相关 mixins