### PR TITLE
Fix network packet corruption in structure block mixin and NullPointerException in data injectors

### DIFF
--- a/src/main/java/com/smallmanseries/farlandstraveler/DataInjectors.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/DataInjectors.java
@@ -129,7 +129,7 @@ public class DataInjectors {
      * @param biomeSource 需要包装的生物群系源，一个JSON元素
      */
     public static void setBiomeSource(JsonObject generator, JsonElement biomeSource) {
-        if (!biomeSource.isJsonNull()) {
+        if (biomeSource != null && !biomeSource.isJsonNull()) {
             int dist = SectionPos.blockToSectionCoord(Config.FAR_LANDS_DISTANCE.getAsInt());
             JsonObject biomeSourceNew = new JsonObject();
             biomeSourceNew.addProperty("type", "farlandstraveler:box_select");

--- a/src/main/java/com/smallmanseries/farlandstraveler/mixin/structureblock/ServerboundSetStructureBlockPacketMixin.java
+++ b/src/main/java/com/smallmanseries/farlandstraveler/mixin/structureblock/ServerboundSetStructureBlockPacketMixin.java
@@ -1,44 +1,20 @@
 package com.smallmanseries.farlandstraveler.mixin.structureblock;
 
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Vec3i;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.game.ServerboundSetStructureBlockPacket;
-import net.minecraft.util.Mth;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ServerboundSetStructureBlockPacket.class)
 public abstract class ServerboundSetStructureBlockPacketMixin {
 
-    @Shadow
-    @Final
-    @Mutable
-    private BlockPos offset;
-
-    @Shadow
-    @Final
-    @Mutable
-    private Vec3i size;
-
-    @Inject(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", at = {@At("RETURN")})
-    public void read(FriendlyByteBuf input, CallbackInfo ci) {
-        this.offset = new BlockPos(Mth.clamp(input.readVarInt(), Integer.MIN_VALUE, Integer.MAX_VALUE), Mth.clamp(input.readVarInt(), Integer.MIN_VALUE, Integer.MAX_VALUE), Mth.clamp(input.readVarInt(), Integer.MIN_VALUE, Integer.MAX_VALUE));
-        this.size = new BlockPos(Mth.clamp(input.readVarInt(), 0, Integer.MAX_VALUE), Mth.clamp(input.readVarInt(), 0, Integer.MAX_VALUE), Mth.clamp(input.readVarInt(), 0, Integer.MAX_VALUE));
+    @ModifyConstant(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", constant = @Constant(intValue = 48))
+    private int maxLoadSize(int value) {
+        return Integer.MAX_VALUE;
     }
 
-    @Inject(method = "write(Lnet/minecraft/network/FriendlyByteBuf;)V", at = @At("RETURN"))
-    public void write(FriendlyByteBuf output, CallbackInfo ci) {
-        output.writeVarInt(this.offset.getX());
-        output.writeVarInt(this.offset.getY());
-        output.writeVarInt(this.offset.getZ());
-        output.writeVarInt(this.size.getX());
-        output.writeVarInt(this.size.getY());
-        output.writeVarInt(this.size.getZ());
+    @ModifyConstant(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", constant = @Constant(intValue = -48))
+    private int minLoadSize(int value) {
+        return Integer.MIN_VALUE;
     }
 }


### PR DESCRIPTION
1. Replaced broken network buffer re-reading and writing in `ServerboundSetStructureBlockPacketMixin` with `@ModifyConstant` hooks on size/offset bounds to prevent `IndexOutOfBoundsException` and packet corruption.
2. Added a null check in `DataInjectors.setBiomeSource` before evaluating `JsonElement.isJsonNull()` to avoid `NullPointerException` when JSON keys are absent.